### PR TITLE
Corrige problema no botão de trocar foto do documento

### DIFF
--- a/src/app/senddocument/senddocument.component.ts
+++ b/src/app/senddocument/senddocument.component.ts
@@ -272,6 +272,7 @@ export class SenddocumentComponent implements OnInit {
       this.stopCameraStreams();
 
       this.btnControllers = true;
+      this.isLoaded = false;
     }
   }
 


### PR DESCRIPTION
Clicar no botão "Trocar foto" no envio de documentos desabilitava o botão "Enviar documento" indefinidamente, impedindo o término do fluxo.