### PR TITLE
Ajuste de mensagem de livness inválido apenas para 300.1

### DIFF
--- a/src/app/iproov/iproov.component.ts
+++ b/src/app/iproov/iproov.component.ts
@@ -275,11 +275,10 @@ export class IproovComponent implements OnInit {
             (response: any) => {
                 switch (iproovStatus) {
                     case 'passed':
-                        if (response.body.codID !== 300.1 || response.body.codID !== 300.2) {
-                            this.statusRequest = 'Enviado com sucesso';
-                        } else {
-                            console.log(response)
+                        if (response.body.codID === 300.1 || response.body.codID === 300.2) {
                             this.statusRequest = 'Prova de Vida reprovada. Insira uma nova appkey e tente novamente.';
+                        } else {
+                            this.statusRequest = 'Enviado com sucesso';
                         }
                         break;
                     case 'failed':

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,9 +5,6 @@
 export const environment = {
   production: false,
    apiUrl: 'https://hml.certiface.com.br',
- // apiUrl: 'http://localhost:8080',
- //  apiUrl: 'https://www.certiface.com.br',
- // apiUrl: 'http://facecaptchav2.internal.dev.certiface.io',
 
   DeviceKeyIdentifier: 'dF2CabwQ6OCLFJaV2QqZhP7OUErHv0uz',
   PublicFaceScanEncryptionKey:


### PR DESCRIPTION
### Correções de bugs:
- Valida especificamente o 300.1 e 300.2 como únicos codIDs inválidos.